### PR TITLE
Updated syslog call.

### DIFF
--- a/README
+++ b/README
@@ -3,21 +3,20 @@ Syslog client for Windows
 
 This is bare-bones client code for using syslog on Windows.
 
-The syslog.h header file contains Windows specific information.  In
+The syslog.h header file contains Windows specific information. In
 particular, users of this code need to call init_syslog() prior to
-calling any of the syslog functions.  This limitation may be fixed in
+calling any of the syslog functions. This limitation may be fixed in
 the future.
 
 TODO:
 
 - Remove requirement for init_syslog().
 
-- Make threading more efficient.  As it is, all syslog calls are
-  serialized.  Each thread should be able invoke syslog without
+- Make threading more efficient. As it is, all syslog calls are
+  serialized. Each thread should be able to invoke syslog without
   blocking on each other.
 
 - Add a makefile and build a library and perhaps an SxS assembly.
-
 
 -----
 Asanka Herath <asanka@secure-endpoints.com>

--- a/syslog.h
+++ b/syslog.h
@@ -177,7 +177,7 @@ extern void openlog (char *__ident, int __option, int __facility);
 extern int setlogmask (int __mask);
 
 /* Generate a log message using FMT string and option arguments.  */
-extern void syslog (int __pri, char *__fmt, ...);
+extern void syslog (int __pri, const char *__fmt, ...);
 
 /* Generate a log message using FMT and using arguments pointed to by AP.  */
 extern void vsyslog (int __pri, char *__fmt, va_list __ap);

--- a/syslogc.c
+++ b/syslogc.c
@@ -271,7 +271,7 @@ int setlogmask( int mask )
  *
  * Generate a log message using FMT string and option arguments.
  */
-void syslog( int pri, char* fmt, ... )
+void syslog( int pri, const char *fmt, ... )
 {
     va_list ap;
 


### PR DESCRIPTION
Made FMT argument constant in conformance to native call.
And, it would avoid the 'const char *' to 'char *' errors.